### PR TITLE
Remove pulp_auth and elasticsearch

### DIFF
--- a/satellite_sanity_lib/rules/sat6_hammer_ping.py
+++ b/satellite_sanity_lib/rules/sat6_hammer_ping.py
@@ -13,7 +13,7 @@ def main(data):
                 failed_services.add(service)
         return failed_services
 
-    expected_services = ('candlepin', 'candlepin_auth', 'pulp', 'pulp_auth', 'elasticsearch', 'foreman_tasks')
+    expected_services = ('candlepin', 'candlepin_auth', 'pulp', 'foreman_tasks')
     seen_services = set()
     failed_services = set()   # not a list to keep this unique
     service = None


### PR DESCRIPTION
Those no longer pop up in hammer ping output, which always makes this
test fail.